### PR TITLE
Docs/swagger configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,11 @@
 			<artifactId>java-jwt</artifactId>
 			<version>4.4.0</version>
 		</dependency>
+		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+			<version>2.1.0</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/poke/center/api/controller/NurseController.java
+++ b/src/main/java/poke/center/api/controller/NurseController.java
@@ -1,5 +1,6 @@
 package poke.center.api.controller;
 
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
@@ -19,6 +20,7 @@ import java.util.List;
 
 @RestController
 @RequestMapping("nurse")
+@SecurityRequirement(name = "bearer-key")
 public class NurseController {
 
     @Autowired

--- a/src/main/java/poke/center/api/controller/NurseController.java
+++ b/src/main/java/poke/center/api/controller/NurseController.java
@@ -1,10 +1,20 @@
 package poke.center.api.controller;
 
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import poke.center.api.domain.user.UserRegisterData;
 
 @Controller
 @RequestMapping("nurse")
 public class NurseController {
 
+
+    @PostMapping("/register")
+    public ResponseEntity nurseRegister(@RequestBody @Valid UserRegisterData user) {
+
+    }
 }

--- a/src/main/java/poke/center/api/controller/NurseController.java
+++ b/src/main/java/poke/center/api/controller/NurseController.java
@@ -1,20 +1,55 @@
 package poke.center.api.controller;
 
 import jakarta.validation.Valid;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import poke.center.api.domain.role.Role;
+import poke.center.api.domain.role.RoleRepository;
+import poke.center.api.domain.user.User;
 import poke.center.api.domain.user.UserRegisterData;
+import poke.center.api.domain.user.UserRepository;
+
+import java.util.HashSet;
+import java.util.Set;
 
 @Controller
 @RequestMapping("nurse")
 public class NurseController {
 
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private RoleRepository roleRepository;
 
     @PostMapping("/register")
-    public ResponseEntity nurseRegister(@RequestBody @Valid UserRegisterData user) {
+    public ResponseEntity nurseRegister(@RequestBody @Valid UserRegisterData data) {
 
+        UserDetails user = userRepository.findByLogin(data.login());
+        if (user != null) {
+            return ResponseEntity.unprocessableEntity().body("Username not available");
+        }
+
+        Role role = roleRepository.findByName("nurse");
+        if (role == null) {
+            return ResponseEntity.badRequest().body("Invalid role");
+        }
+
+        BCryptPasswordEncoder encoder = new BCryptPasswordEncoder();
+        var newUser = new User(data);
+        newUser.setPassword(encoder.encode(data.password()));
+
+        Set<Role> userRole = new HashSet<>();
+        userRole.add(role);
+        newUser.setRoles(userRole);
+
+        userRepository.save(newUser);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/poke/center/api/controller/NurseController.java
+++ b/src/main/java/poke/center/api/controller/NurseController.java
@@ -1,0 +1,10 @@
+package poke.center.api.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@RequestMapping("nurse")
+public class NurseController {
+
+}

--- a/src/main/java/poke/center/api/controller/NurseController.java
+++ b/src/main/java/poke/center/api/controller/NurseController.java
@@ -3,10 +3,10 @@ package poke.center.api.controller;
 import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 import poke.center.api.domain.role.Role;
 import poke.center.api.domain.role.RoleRepository;
 import poke.center.api.domain.role.validation.RoleValidator;
@@ -17,7 +17,7 @@ import poke.center.api.domain.user.validation.UserValidator;
 
 import java.util.List;
 
-@Controller
+@RestController
 @RequestMapping("nurse")
 public class NurseController {
 

--- a/src/main/java/poke/center/api/controller/TrainerController.java
+++ b/src/main/java/poke/center/api/controller/TrainerController.java
@@ -3,6 +3,7 @@ package poke.center.api.controller;
 import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.web.bind.annotation.*;
 import poke.center.api.domain.role.Role;
@@ -26,20 +27,19 @@ public class TrainerController {
     @PostMapping("/register")
     public ResponseEntity trainerRegister(@RequestBody @Valid UserRegisterData data) {
 
-        var user = userRepository.findByLogin(data.login());
-
+        UserDetails user = userRepository.findByLogin(data.login());
         if (user != null) {
             return ResponseEntity.unprocessableEntity().body("Username not available");
+        }
+
+        Role role = roleRepository.findByName("trainer");
+        if (role == null) {
+            return ResponseEntity.badRequest().body("Invalid role");
         }
 
         BCryptPasswordEncoder encoder = new BCryptPasswordEncoder();
         var newUser = new User(data);
         newUser.setPassword(encoder.encode(data.password()));
-
-        var role = roleRepository.findByName("trainer");
-        if (role == null) {
-            return ResponseEntity.badRequest().body("Invalid role");
-        }
 
         Set<Role> userRole = new HashSet<>();
         userRole.add(role);

--- a/src/main/java/poke/center/api/controller/TrainerController.java
+++ b/src/main/java/poke/center/api/controller/TrainerController.java
@@ -49,9 +49,4 @@ public class TrainerController {
         return ResponseEntity.noContent().build();
     }
 
-    @GetMapping("/test")
-    public ResponseEntity test() {
-        return ResponseEntity.ok("dale");
-    }
-
 }

--- a/src/main/java/poke/center/api/domain/role/validation/RoleExistValidator.java
+++ b/src/main/java/poke/center/api/domain/role/validation/RoleExistValidator.java
@@ -1,0 +1,22 @@
+package poke.center.api.domain.role.validation;
+
+import jakarta.validation.ValidationException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import poke.center.api.domain.role.Role;
+import poke.center.api.domain.role.RoleRepository;
+
+@Component
+public class RoleExistValidator implements RoleValidator{
+
+    @Autowired
+    private RoleRepository roleRepository;
+
+    @Override
+    public void validate(Role role) {
+        if (role == null) {
+            throw new ValidationException("Invalid Role");
+        }
+    }
+}

--- a/src/main/java/poke/center/api/domain/role/validation/RoleValidator.java
+++ b/src/main/java/poke/center/api/domain/role/validation/RoleValidator.java
@@ -1,0 +1,7 @@
+package poke.center.api.domain.role.validation;
+
+import poke.center.api.domain.role.Role;
+
+public interface RoleValidator {
+    void validate(Role role);
+}

--- a/src/main/java/poke/center/api/domain/user/User.java
+++ b/src/main/java/poke/center/api/domain/user/User.java
@@ -41,6 +41,11 @@ public class User implements UserDetails {
         this.password = data.password();
     }
 
+
+    public void registerAsNurse() {
+
+    }
+
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
 

--- a/src/main/java/poke/center/api/domain/user/User.java
+++ b/src/main/java/poke/center/api/domain/user/User.java
@@ -6,6 +6,7 @@ import lombok.*;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import poke.center.api.domain.role.Role;
 
 import java.util.Collection;
@@ -39,6 +40,15 @@ public class User implements UserDetails {
         this.name = data.name();
         this.login = data.login();
         this.password = data.password();
+    }
+
+    public void create(Role role) {
+        BCryptPasswordEncoder encoder = new BCryptPasswordEncoder();
+        this.setPassword(encoder.encode(this.getPassword()));
+
+        Set<Role> userRole = new HashSet<>();
+        userRole.add(role);
+        this.setRoles(userRole);
     }
 
     @Override

--- a/src/main/java/poke/center/api/domain/user/User.java
+++ b/src/main/java/poke/center/api/domain/user/User.java
@@ -41,11 +41,6 @@ public class User implements UserDetails {
         this.password = data.password();
     }
 
-
-    public void registerAsNurse() {
-
-    }
-
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
 

--- a/src/main/java/poke/center/api/domain/user/User.java
+++ b/src/main/java/poke/center/api/domain/user/User.java
@@ -56,7 +56,7 @@ public class User implements UserDetails {
 
         Set<SimpleGrantedAuthority> authorities = new HashSet<>();
         this.getRoles().forEach(role -> {
-            authorities.add(new SimpleGrantedAuthority(role.getName().toUpperCase()));
+            authorities.add(new SimpleGrantedAuthority(role.getName()));
         });
         return authorities;
     }

--- a/src/main/java/poke/center/api/domain/user/validation/UserLoginAlreadyInUseValidator.java
+++ b/src/main/java/poke/center/api/domain/user/validation/UserLoginAlreadyInUseValidator.java
@@ -2,7 +2,6 @@ package poke.center.api.domain.user.validation;
 
 import jakarta.validation.ValidationException;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
 import poke.center.api.domain.user.UserRegisterData;

--- a/src/main/java/poke/center/api/domain/user/validation/UserLoginAlreadyInUseValidator.java
+++ b/src/main/java/poke/center/api/domain/user/validation/UserLoginAlreadyInUseValidator.java
@@ -1,0 +1,24 @@
+package poke.center.api.domain.user.validation;
+
+import jakarta.validation.ValidationException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+import poke.center.api.domain.user.UserRegisterData;
+import poke.center.api.domain.user.UserRepository;
+
+@Component
+public class UserLoginAlreadyInUseValidator implements UserValidator{
+
+    @Autowired
+    private UserRepository userRepository;
+
+    public void validate(UserRegisterData data) {
+
+        UserDetails user = userRepository.findByLogin(data.login());
+        if (user != null) {
+            throw new ValidationException("Username already in use");
+        }
+    }
+}

--- a/src/main/java/poke/center/api/domain/user/validation/UserValidator.java
+++ b/src/main/java/poke/center/api/domain/user/validation/UserValidator.java
@@ -1,0 +1,8 @@
+package poke.center.api.domain.user.validation;
+
+import poke.center.api.domain.user.UserRegisterData;
+
+public interface UserValidator {
+
+    void validate(UserRegisterData data);
+}

--- a/src/main/java/poke/center/api/infra/exception/ExceptionTreatment.java
+++ b/src/main/java/poke/center/api/infra/exception/ExceptionTreatment.java
@@ -1,8 +1,8 @@
 package poke.center.api.infra.exception;
 
 import jakarta.persistence.EntityNotFoundException;
+import jakarta.validation.ValidationException;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -17,9 +17,13 @@ public class ExceptionTreatment {
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity tratarErro400(MethodArgumentNotValidException ex) {
+    public ResponseEntity error400(MethodArgumentNotValidException ex) {
         var erros = ex.getFieldErrors();
         return ResponseEntity.badRequest().body(erros.stream().map(ValidationErrorData::new).toList());
+    }
+    @ExceptionHandler(ValidationException.class)
+    public ResponseEntity validationError(ValidationException ex) {
+        return ResponseEntity.badRequest().body(ex.getMessage());
     }
 
     private record ValidationErrorData(String field, String message) {

--- a/src/main/java/poke/center/api/infra/secutiry/SecurityConfigurations.java
+++ b/src/main/java/poke/center/api/infra/secutiry/SecurityConfigurations.java
@@ -31,6 +31,7 @@ public class SecurityConfigurations {
                                 authorize
                                 .requestMatchers(HttpMethod.POST, "/login").permitAll()
                                 .requestMatchers(HttpMethod.POST, "/trainer/register").permitAll()
+                                .requestMatchers(HttpMethod.POST, "/nurse/register").permitAll()
                                 .anyRequest().authenticated())
                 .addFilterBefore(securityFilter, UsernamePasswordAuthenticationFilter.class)
                 .build();

--- a/src/main/java/poke/center/api/infra/secutiry/SecurityConfigurations.java
+++ b/src/main/java/poke/center/api/infra/secutiry/SecurityConfigurations.java
@@ -32,6 +32,7 @@ public class SecurityConfigurations {
                                 .requestMatchers(HttpMethod.POST, "/login").permitAll()
                                 .requestMatchers(HttpMethod.POST, "/trainer/register").permitAll()
                                 .requestMatchers(HttpMethod.POST, "/nurse/**").hasAuthority("nurse")
+                                .requestMatchers("/v3/api-docs/**", "/swagger-ui.html", "/swagger-ui/**").permitAll()
                                 .anyRequest().authenticated())
                 .addFilterBefore(securityFilter, UsernamePasswordAuthenticationFilter.class)
                 .build();

--- a/src/main/java/poke/center/api/infra/secutiry/SecurityConfigurations.java
+++ b/src/main/java/poke/center/api/infra/secutiry/SecurityConfigurations.java
@@ -31,7 +31,7 @@ public class SecurityConfigurations {
                                 authorize
                                 .requestMatchers(HttpMethod.POST, "/login").permitAll()
                                 .requestMatchers(HttpMethod.POST, "/trainer/register").permitAll()
-                                .requestMatchers(HttpMethod.POST, "/nurse/register").permitAll()
+                                .requestMatchers(HttpMethod.POST, "/nurse/**").hasAuthority("nurse")
                                 .anyRequest().authenticated())
                 .addFilterBefore(securityFilter, UsernamePasswordAuthenticationFilter.class)
                 .build();

--- a/src/main/java/poke/center/api/infra/springdoc/SpringDocConfiguration.java
+++ b/src/main/java/poke/center/api/infra/springdoc/SpringDocConfiguration.java
@@ -2,6 +2,7 @@ package poke.center.api.infra.springdoc;
 
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -11,8 +12,17 @@ public class SpringDocConfiguration {
     @Bean
     public OpenAPI customOpenAPI() {
         return new OpenAPI()
+                .info(getApiInfo())
                 .components(new Components()
                         .addSecuritySchemes("bearer-key",
                                 new SecurityScheme().type(SecurityScheme.Type.HTTP).scheme("bearer").bearerFormat("JWT")));
+    }
+
+    private Info getApiInfo() {
+        Info apiInfo = new Info();
+        apiInfo.setTitle("pokecenter");
+        apiInfo.setDescription("an experience of using and managing one pokecenter!");
+        apiInfo.setVersion("1.0");
+        return apiInfo;
     }
 }

--- a/src/main/java/poke/center/api/infra/springdoc/SpringDocConfiguration.java
+++ b/src/main/java/poke/center/api/infra/springdoc/SpringDocConfiguration.java
@@ -1,0 +1,18 @@
+package poke.center.api.infra.springdoc;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SpringDocConfiguration {
+    @Bean
+    public OpenAPI customOpenAPI() {
+        return new OpenAPI()
+                .components(new Components()
+                        .addSecuritySchemes("bearer-key",
+                                new SecurityScheme().type(SecurityScheme.Type.HTTP).scheme("bearer").bearerFormat("JWT")));
+    }
+}

--- a/src/main/resources/db/migration/V17__create_default_nurse_user.sql
+++ b/src/main/resources/db/migration/V17__create_default_nurse_user.sql
@@ -1,0 +1,4 @@
+insert into user (name, login, password) VALUES
+("Nurse", "kingnothing", "$2a$12$NTWO1x6TZzx1tarPjvdegOZpVJVPrt2ENIY9CUpgwwsLlDnDJTvAK");
+
+insert into userRole values (LAST_INSERT_ID(), 2);

--- a/src/test/java/poke/center/api/controller/NurseControllerTest.java
+++ b/src/test/java/poke/center/api/controller/NurseControllerTest.java
@@ -1,0 +1,7 @@
+package poke.center.api.controller;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class NurseControllerTest {
+
+}

--- a/src/test/java/poke/center/api/controller/NurseControllerTest.java
+++ b/src/test/java/poke/center/api/controller/NurseControllerTest.java
@@ -56,7 +56,7 @@ class NurseControllerTest {
 
     @Test
     @DisplayName("It should return 422 code because username already exists")
-    void scenario2() throws Exception {
+    void nurseRegisterScenario2() throws Exception {
 
         var response = mockMvc.perform(
                 post("/trainer/register")

--- a/src/test/java/poke/center/api/controller/NurseControllerTest.java
+++ b/src/test/java/poke/center/api/controller/NurseControllerTest.java
@@ -1,7 +1,37 @@
 package poke.center.api.controller;
 
-import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.json.JacksonTester;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import poke.center.api.domain.user.UserRegisterData;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 
 class NurseControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private JacksonTester<UserRegisterData> nurseRegisterDataJson;
+
+    @Test
+    @DisplayName("It should return code 204 for successfully register")
+    void nurseRegisterScenario1() throws Exception {
+
+        var response = mockMvc.perform(
+                post("/nurse/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(nurseRegisterDataJson.write(
+                                new UserRegisterData("teste", "teste", "12345678")
+                        ).getJson())
+        ).andReturn().getResponse();
+
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.NO_CONTENT.value());
+    }
 
 }

--- a/src/test/java/poke/center/api/controller/NurseControllerTest.java
+++ b/src/test/java/poke/center/api/controller/NurseControllerTest.java
@@ -12,6 +12,7 @@ import org.springframework.boot.test.json.JacksonTester;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.jdbc.JdbcTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
@@ -40,6 +41,7 @@ class NurseControllerTest {
 
 
     @Test
+    @WithMockUser(authorities = {"nurse"})
     @DisplayName("It should return code 204 for successfully register")
     void nurseRegisterScenario1() throws Exception {
 
@@ -55,18 +57,35 @@ class NurseControllerTest {
     }
 
     @Test
-    @DisplayName("It should return 422 code because username already exists")
+    @WithMockUser(authorities = {"nurse"})
+    @DisplayName("It should return 400 code because username already exists")
     void nurseRegisterScenario2() throws Exception {
 
         var response = mockMvc.perform(
-                post("/trainer/register")
+                post("/nurse/register")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(nurseRegisterDataJson.write(
                                 new UserRegisterData("teste", "teste", "12345678")
                         ).getJson())
         ).andReturn().getResponse();
 
-        assertThat(response.getStatus()).isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY.value());
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+    }
+
+    @Test
+    @WithMockUser(authorities = {"trainer"})
+    @DisplayName("It should return 403 because user has not nurse authority")
+    void nurseRegisterScenario3() throws Exception {
+
+        var response = mockMvc.perform(
+                post("/nurse/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(nurseRegisterDataJson.write(
+                                new UserRegisterData("teste", "teste", "12345678")
+                        ).getJson())
+        ).andReturn().getResponse();
+
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.FORBIDDEN.value());
     }
 
 }

--- a/src/test/java/poke/center/api/controller/TrainerControllerTest.java
+++ b/src/test/java/poke/center/api/controller/TrainerControllerTest.java
@@ -43,7 +43,6 @@ class TrainerControllerTest {
     }
 
     @Test
-    @WithMockUser
     @DisplayName("It should return code 204 for successfully register")
     void trainerRegisterScenario1() throws Exception {
 

--- a/src/test/java/poke/center/api/controller/TrainerControllerTest.java
+++ b/src/test/java/poke/center/api/controller/TrainerControllerTest.java
@@ -12,7 +12,6 @@ import org.springframework.boot.test.json.JacksonTester;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.jdbc.JdbcTestUtils;
 import org.springframework.test.web.servlet.MockMvc;


### PR DESCRIPTION
# Description
## Added OpenAPI documentation to the project to enable fast access to the application details and functioning

# How to validate
With the project running, access the following endpoints on a Browser (default URL localhost:8080):
- [x] /swagger-ui.html | On this page you should be able to use all the endpoints of the application
![image](https://github.com/Hugosan000/Pokecenter/assets/52075166/b4ac4ecd-942a-4299-8876-ce9b986dfc6e)


- [x] /v3/api-docs | On this page, you should be able to see all the application specifications
![image](https://github.com/Hugosan000/Pokecenter/assets/52075166/ea3fdcc5-f49b-4051-8b78-56d92b0e2251)


On the first link, you should be able to see and use the login and trainer/register endpoints without a JWT token and the nurse/register only with a Token generated from a nurse user login

On the second one, you'll have all the information of the API in a JSON format

# Obs
## The default nurse user is:
* Login: kingnothing
* Password: potatopotato
 